### PR TITLE
iscsi: create longhorn block device node based on lsblk information

### DIFF
--- a/iscsi/iscsi_test.go
+++ b/iscsi/iscsi_test.go
@@ -136,7 +136,8 @@ func (s *TestSuite) TestFlow(c *C) {
 
 	dev, err := GetDevice(s.localIP, t, lun, s.ne)
 	c.Assert(err, IsNil)
-	c.Assert(strings.HasPrefix(dev, "/dev/sd"), Equals, true)
+	c.Assert(strings.HasPrefix(dev.Name, "sd"), Equals, true)
+	c.Assert(dev.Major, Not(Equals), 0)
 
 	err = LogoutTarget(s.localIP, t, s.ne)
 	c.Assert(err, IsNil)
@@ -210,7 +211,8 @@ func (s *TestSuite) TestAio(c *C) {
 
 	dev, err := GetDevice(s.localIP, t, lun, s.ne)
 	c.Assert(err, IsNil)
-	c.Assert(strings.HasPrefix(dev, "/dev/sd"), Equals, true)
+	c.Assert(strings.HasPrefix(dev.Name, "sd"), Equals, true)
+	c.Assert(dev.Major, Not(Equals), 0)
 
 	err = LogoutTarget(s.localIP, t, s.ne)
 	c.Assert(err, IsNil)

--- a/iscsidev/iscsi.go
+++ b/iscsidev/iscsi.go
@@ -2,7 +2,6 @@ package iscsidev
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -27,11 +26,11 @@ var (
 )
 
 type Device struct {
-	Target      string
-	Device      string
-	BackingFile string
-	BSType      string
-	BSOpts      string
+	Target       string
+	KernelDevice *util.KernelDevice
+	BackingFile  string
+	BSType       string
+	BSOpts       string
 
 	targetID int
 }
@@ -132,21 +131,10 @@ func (dev *Device) StartInitator() error {
 	if err := iscsi.LoginTarget(localIP, dev.Target, ne); err != nil {
 		return err
 	}
-	if dev.Device, err = iscsi.GetDevice(localIP, dev.Target, TargetLunID, ne); err != nil {
+	if dev.KernelDevice, err = iscsi.GetDevice(localIP, dev.Target, TargetLunID, ne); err != nil {
 		return err
 	}
 
-	deviceFound := false
-	for i := 0; i < RetryCounts; i++ {
-		if st, err := os.Stat(dev.Device); err == nil && (st.Mode()&os.ModeDevice != 0) {
-			deviceFound = true
-			break
-		}
-		time.Sleep(RetryIntervalSCSI)
-	}
-	if !deviceFound {
-		return fmt.Errorf("Failed to wait for device %s to show up", dev.Device)
-	}
 	return nil
 }
 

--- a/longhorndev/dev.go
+++ b/longhorndev/dev.go
@@ -107,7 +107,7 @@ func (d *LonghornDevice) Start() error {
 
 		d.endpoint = d.getDev()
 
-		logrus.Infof("device %v: SCSI device %s created", d.name, d.scsiDevice.Device)
+		logrus.Infof("device %v: SCSI device %s created", d.name, d.scsiDevice.KernelDevice.Name)
 		break
 	case types.FrontendTGTISCSI:
 		if err := d.scsiDevice.CreateTarget(); err != nil {
@@ -218,7 +218,7 @@ func (d *LonghornDevice) createDev() error {
 		}
 	}
 
-	if err := util.DuplicateDevice(d.scsiDevice.Device, dev); err != nil {
+	if err := util.DuplicateDevice(d.scsiDevice.KernelDevice, dev); err != nil {
 		return err
 	}
 

--- a/util/util.go
+++ b/util/util.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"io"
@@ -16,12 +17,19 @@ import (
 )
 
 const (
-	NSBinary = "nsenter"
+	NSBinary    = "nsenter"
+	LSBLKBinary = "lsblk"
 )
 
 var (
 	cmdTimeout = time.Minute // one minute by default
 )
+
+type KernelDevice struct {
+	Name  string
+	Major int
+	Minor int
+}
 
 func getIPFromAddrs(addrs []net.Addr) string {
 	for _, addr := range addrs {
@@ -255,15 +263,50 @@ func RemoveDevice(dev string) error {
 	return nil
 }
 
-func DuplicateDevice(src, dest string) error {
-	stat := unix.Stat_t{}
-	if err := unix.Stat(src, &stat); err != nil {
-		return fmt.Errorf("Cannot duplicate device because cannot find %s: %v", src, err)
+func GetKnownDevices(ne *NamespaceExecutor) (map[string]*KernelDevice, error) {
+	knownDevices := make(map[string]*KernelDevice)
+
+	/* Example command output
+	   $ lsblk -l -n -o NAME,MAJ:MIN
+	   sda           8:0
+	   sdb           8:16
+	   sdc           8:32
+	   nvme0n1     259:0
+	   nvme0n1p1   259:1
+	   nvme0n1p128 259:2
+	   nvme1n1     259:3
+	*/
+
+	opts := []string{
+		"-l", "-n", "-o", "NAME,MAJ:MIN",
 	}
-	major := int(stat.Rdev / 256)
-	minor := int(stat.Rdev % 256)
-	if err := mknod(dest, major, minor); err != nil {
-		return fmt.Errorf("Cannot duplicate device %s to %s", src, dest)
+
+	output, err := ne.Execute(LSBLKBinary, opts)
+	if err != nil {
+		return knownDevices, err
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	for scanner.Scan() {
+		line := scanner.Text()
+		f := strings.Fields(line)
+		if len(f) == 2 {
+			dev := &KernelDevice{
+				Name: f[0],
+			}
+			if _, err := fmt.Sscanf(f[1], "%d:%d", &dev.Major, &dev.Minor); err != nil {
+				return nil, fmt.Errorf("Invalid major:minor %s for device %s", dev.Name, f[1])
+			}
+			knownDevices[dev.Name] = dev
+		}
+	}
+
+	return knownDevices, nil
+}
+
+func DuplicateDevice(dev *KernelDevice, dest string) error {
+	if err := mknod(dest, dev.Major, dev.Minor); err != nil {
+		return fmt.Errorf("Cannot create device node %s for device %s", dest, dev.Name)
 	}
 	if err := os.Chmod(dest, 0660); err != nil {
 		return fmt.Errorf("Couldn't change permission of the device %s: %s", dest, err)
@@ -274,7 +317,7 @@ func DuplicateDevice(src, dest string) error {
 func mknod(device string, major, minor int) error {
 	var fileMode os.FileMode = 0660
 	fileMode |= unix.S_IFBLK
-	dev := int((major << 8) | (minor & 0xff) | ((minor & 0xfff00) << 12))
+	dev := int(unix.Mkdev(uint32(major), uint32(minor)))
 
 	logrus.Infof("Creating device %s %d:%d", device, major, minor)
 	return unix.Mknod(device, uint32(fileMode), dev)


### PR DESCRIPTION
we now retrieve the block device information via lsblk for the device name
returned by iscsiadm which should be the kernel name for the new scsci device

instead of relying on the operating systems iscsi device node
which might not have been created as in the case when there is
already a file/link with the same name present on the /dev filesystem

longhorn/longhorn#1223

Signed-off-by: Joshua Moody <joshua.moody@rancher.com>
