### PR TITLE
Keep err for method scope

### DIFF
--- a/iscsidev/iscsi.go
+++ b/iscsidev/iscsi.go
@@ -109,9 +109,8 @@ func (dev *Device) StartInitator() error {
 	}
 
 	// Setup initiator
-	err = nil
 	for i := 0; i < RetryCounts; i++ {
-		err = iscsi.DiscoverTarget(localIP, dev.Target, ne)
+		err := iscsi.DiscoverTarget(localIP, dev.Target, ne)
 		if iscsi.IsTargetDiscovered(localIP, dev.Target, ne) {
 			break
 		}


### PR DESCRIPTION
~Seems like the error could be nil hence making warning seems redundant.~
Keep err for method scope.