### PR TITLE
allow containerd-shim in finding namespace

### DIFF
--- a/util/process.go
+++ b/util/process.go
@@ -7,8 +7,9 @@ import (
 )
 
 const (
-	DockerdProcess    = "dockerd"
-	ContainerdProcess = "containerd"
+	DockerdProcess        = "dockerd"
+	ContainerdProcess     = "containerd"
+	ContainerdProcessShim = "containerd-shim"
 )
 
 type ProcessFinder struct {
@@ -53,13 +54,12 @@ func (p *ProcessFinder) FindAncestorByName(ancestorProcess string) (*linuxproc.P
 
 func GetHostNamespacePath(hostProcPath string) string {
 	pf := NewProcessFinder(hostProcPath)
-	proc, err := pf.FindAncestorByName(DockerdProcess)
-	if err != nil {
-		proc, err = pf.FindAncestorByName(ContainerdProcess)
-		// fall back to use pid 1
-		if err != nil {
-			return fmt.Sprintf("%s/%d/ns/", hostProcPath, 1)
+	containerNames := []string{DockerdProcess, ContainerdProcess, ContainerdProcessShim}
+	for _, name := range containerNames {
+		proc, err := pf.FindAncestorByName(name)
+		if err == nil {
+			return fmt.Sprintf("%s/%d/ns/", hostProcPath, proc.Pid)
 		}
 	}
-	return fmt.Sprintf("%s/%d/ns/", hostProcPath, proc.Pid)
+	return fmt.Sprintf("%s/%d/ns/", hostProcPath, 1)
 }

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -44,9 +44,13 @@ func (s *TestSuite) TestFindDockerdProcess(c *C) {
 	ps, err := finder.FindAncestorByName(DockerdProcess)
 	if err != nil {
 		ps, err = finder.FindAncestorByName(ContainerdProcess)
+		if err != nil {
+			ps, err = finder.FindAncestorByName(ContainerdProcessShim)
+		}
 	}
 	c.Assert(err, IsNil)
 	c.Assert(ps, NotNil)
+	c.Assert(fmt.Sprintf("%s/%d/ns/", procPath, ps.Pid), Equals, GetHostNamespacePath(procPath))
 
 	notExistProcess := "dockerdddd"
 	ps, err = finder.FindAncestorByName(notExistProcess)


### PR DESCRIPTION

This patch is to support longhorn working with kubernetes which
run inside a container instead of a VM. Many of the longhorn
processes need to use go-iscsi-helper's process.go to get the
longhorn container's parent process and namesapce for mount
and network operations.

Related to: https://github.com/longhorn/longhorn/issues/5693

The current process.go code defines two process name strings:
	DockerdProcess    = "dockerd"
	ContainerdProcess = "containerd"

When the FindAncestorByName() works recursively up, it can not
find either of the above process names, thus it default to
process 'Init' with pid 1. This works if the kubernetes and
longhorn running inside a VM.

When running kubernetes/longhorn inside a container, this
results also default into the 'Init' process with pid 1.
This will cause the namespace to be invalid for longhorn.
Here is an example of debug output for the recursive search:

 (0) longhorn-manage, id 28641;
 (1) containerd-shim, id 26544;
 (2) containerd-shim, id 1738;
 (3) init, id 1;

This patch introduces a new string 'containerd-shim', the function
stops at the above process with PID of 26544, that seems to
allow the kubernetes/longhorn to work within the container.

For VM case, it does not have above (1) case, it only has 0 > 2 > 3,
with this patch, it stops at the PID of 1738, which should be in
the same namespace as it defaults to 'Init'.
