### PR TITLE
fix: lazy umount LUKS device when engine was crashed unexpectedly and then re-attach to the same node

### DIFF
--- a/longhorndev/dev.go
+++ b/longhorndev/dev.go
@@ -19,6 +19,7 @@ import (
 const (
 	SocketDirectory = "/var/run"
 	DevPath         = "/dev/longhorn/"
+	LuksDevPath     = "/dev/mapper/"
 
 	WaitInterval = time.Second
 	WaitCount    = 30
@@ -200,6 +201,10 @@ func (d *LonghornDevice) shutdownFrontend() error {
 		if err := util.RemoveDevice(dev); err != nil {
 			return errors.Wrapf(err, "device %v: failed to remove device %s", d.name, dev)
 		}
+		luksDev := d.getLuksDev()
+		if err := util.LazyUnmountDevice(luksDev); err != nil {
+			return errors.Wrapf(err, "device %v: failed to umount Luks device %s", d.name, luksDev)
+		}
 		if err := d.scsiDevice.StopInitiator(); err != nil {
 			return errors.Wrapf(err, "device %v: failed to stop iSCSI device", d.name)
 		}
@@ -256,6 +261,11 @@ func (d *LonghornDevice) GetSocketPath() string {
 // call with lock hold
 func (d *LonghornDevice) getDev() string {
 	return filepath.Join(DevPath, d.name)
+}
+
+// call with lock hold
+func (d *LonghornDevice) getLuksDev() string {
+	return filepath.Join(LuksDevPath, d.name)
 }
 
 // call with lock hold

--- a/util/util.go
+++ b/util/util.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 
+	lhns "github.com/longhorn/go-common-libs/ns"
 	lhtypes "github.com/longhorn/go-common-libs/types"
 )
 
@@ -68,6 +69,16 @@ func RemoveFile(file string) error {
 	return nil
 }
 
+func LazyUnmountDevice(dev string) error {
+	// os.Stat() to check if the device exists, if it doesn't exist, we can skip the unmounting and treat it as a success!
+	if _, err := os.Stat(dev); err == nil {
+		if err := lazyUnmount(dev); err != nil {
+			return errors.Wrapf(err, "failed to umount device %s", dev)
+		}
+	}
+	return nil
+}
+
 func RemoveDevice(dev string) error {
 	if _, err := os.Stat(dev); err == nil {
 		if err := remove(dev); err != nil {
@@ -118,4 +129,25 @@ func remove(path string) error {
 	case <-time.After(30 * time.Second):
 		return fmt.Errorf("timeout trying to delete %s", path)
 	}
+}
+
+func lazyUnmount(path string) error {
+	namespaces := []lhtypes.Namespace{lhtypes.NamespaceMnt, lhtypes.NamespaceNet}
+	nsexec, err := lhns.NewNamespaceExecutor(lhtypes.ProcessNone, lhtypes.HostProcDirectory, namespaces)
+	if err != nil {
+		return err
+	}
+
+	output, err := nsexec.Execute(nil, "umount", []string{"-l", path}, lhtypes.ExecuteDefaultTimeout)
+	if err != nil {
+		if strings.Contains(err.Error(), "not mounted") {
+			// The device is already unmounted. We can safely ignore the error and treat it as a success!
+			logrus.WithError(err).Debugf("Device %s is already unmounted.\n", path)
+			return nil
+		}
+		return errors.Wrapf(err, "failed to umount %s: %s", path, string(output))
+	}
+
+	logrus.Debugf("Lazy umount device %s without the error 'not mounted'.\n", path)
+	return nil
 }


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # longhorn/longhorn#11510

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
